### PR TITLE
[Refactoring] refactor generators

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Grafite\FormMaker\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+class BaseCommand extends GeneratorCommand
+{
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'form';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/baseform.php';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Http\Forms';
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return ucfirst(trim($this->argument('name'))) . ucfirst($this->type);
+    }
+
+    /**
+     * Replace other variables.
+     *
+     * @param string $stub
+     * @param array $keys
+     * @param array $values
+     *
+     * @return $this
+     */
+    protected function replaceOtherVariables(&$stub, $keys, $values)
+    {
+        $stub = str_replace(
+            $keys,
+            $values,
+            $stub
+        );
+
+        return $this;
+    }
+}

--- a/src/Commands/MakeBaseFormCommand.php
+++ b/src/Commands/MakeBaseFormCommand.php
@@ -2,16 +2,16 @@
 
 namespace Grafite\FormMaker\Commands;
 
-use Illuminate\Console\Command;
+use Illuminate\Console\GeneratorCommand;
 
-class MakeBaseFormCommand extends Command
+class MakeBaseFormCommand extends BaseCommand
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $signature = 'make:base-form {entity}';
+    protected $name = 'make:base-form';
 
     /**
      * The console command description.
@@ -19,28 +19,4 @@ class MakeBaseFormCommand extends Command
      * @var string
      */
     protected $description = 'Create a new base form';
-
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle()
-    {
-        $entity = $this->argument('entity');
-
-        $fileName = ucfirst($entity).'Form.php';
-        $file = app_path('Http/Forms/'.$fileName);
-        $stub = __DIR__.'/stubs/baseform.php';
-
-        $contents = file_get_contents($stub);
-
-        $contents = str_replace('{form}', $entity.'Form', $contents);
-
-        if (!file_exists($file)) {
-            file_put_contents(app_path('Http/Forms/'.$fileName), $contents);
-        }
-
-        $this->info('You have a base form for '.$entity);
-    }
 }

--- a/src/Commands/MakeBaseFormCommand.php
+++ b/src/Commands/MakeBaseFormCommand.php
@@ -2,8 +2,6 @@
 
 namespace Grafite\FormMaker\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-
 class MakeBaseFormCommand extends BaseCommand
 {
     /**

--- a/src/Commands/MakeFieldCommand.php
+++ b/src/Commands/MakeFieldCommand.php
@@ -2,17 +2,16 @@
 
 namespace Grafite\FormMaker\Commands;
 
-use Illuminate\Support\Str;
-use Illuminate\Console\Command;
+use Illuminate\Console\GeneratorCommand;
 
-class MakeFieldCommand extends Command
+class MakeFieldCommand extends BaseCommand
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $signature = 'make:field {field}';
+    protected $name = 'make:field';
 
     /**
      * The console command description.
@@ -22,31 +21,31 @@ class MakeFieldCommand extends Command
     protected $description = 'Create a new field';
 
     /**
-     * Execute the console command.
+     * The type of class being generated.
      *
-     * @return mixed
+     * @var string
      */
-    public function handle()
+    protected $type = 'field';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
     {
-        $field = $this->argument('field');
+        return __DIR__ . '/stubs/field.php';
+    }
 
-        $fileName = ucfirst($field).'.php';
-
-        if (!is_dir(app_path('Http/Forms/Fields'))) {
-            mkdir(app_path('Http/Forms/Fields'));
-        }
-
-        $file = app_path('Http/Forms/Fields/'.$fileName);
-        $stub = __DIR__.'/stubs/field.php';
-
-        $contents = file_get_contents($stub);
-
-        $contents = str_replace('{field}', $field, $contents);
-
-        if (!file_exists($file)) {
-            file_put_contents(app_path('Http/Forms/Fields/'.$fileName), $contents);
-        }
-
-        $this->info('You have a form for '.$field.' field.');
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Http\Fields';
     }
 }

--- a/src/Commands/MakeFieldCommand.php
+++ b/src/Commands/MakeFieldCommand.php
@@ -2,8 +2,6 @@
 
 namespace Grafite\FormMaker\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-
 class MakeFieldCommand extends BaseCommand
 {
     /**

--- a/src/Commands/stubs/baseform.php
+++ b/src/Commands/stubs/baseform.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Forms;
+namespace DummyNamespace;
 
 use Grafite\FormMaker\Forms\BaseForm;
 
-class {form} extends BaseForm
+class DummyClass extends BaseForm
 {
     /**
      * The form route

--- a/src/Commands/stubs/field.php
+++ b/src/Commands/stubs/field.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Forms\Fields;
+namespace DummyNamespace;
 
 use Grafite\FormMaker\Fields\Field;
 
-class {field} extends Field
+class DummyClass extends Field
 {
     /**
      * Input type

--- a/src/Commands/stubs/form.php
+++ b/src/Commands/stubs/form.php
@@ -1,18 +1,17 @@
 <?php
 
-namespace App\Http\Forms;
+namespace DummyNamespace;
 
 use Grafite\FormMaker\Forms\ModelForm;
 
-class {form} extends ModelForm
+class DummyClass extends ModelForm
 {
-
     /**
      * The model for the form
      *
      * @var \Illuminate\Database\Eloquent\Model
      */
-    public $model = {model}::class;
+    public $model = DummyModel::class;
 
     /**
      * Required prefix of routes
@@ -22,7 +21,7 @@ class {form} extends ModelForm
      *
      * @var string
      */
-    public $routePrefix = '{prefix}';
+    public $routePrefix = 'DummyPrefix';
 
     /**
      * Buttons and values


### PR DESCRIPTION
Refactor `Field`, `model-form` and `base-form` generators using the laravel `GeneratorCommand`

### Why?

1. No more of `No such of file or directory` error, if the directory doesn't exists, it will be created automatically.

2. The namespaces will be customisable, it is easier to change the namespaces of the classes in the future (better than hardcoding the namespaces in the stubs).

3. It will be easier to add more generators in the future.

4. Commands classes look bit cleaner. 